### PR TITLE
Fixes a mistaken word

### DIFF
--- a/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
@@ -13,7 +13,7 @@ browser-compat: api.FontFaceSet.loadingdone_event
 
 {{APIRef("CSS Font Loading API")}}
 
-The `loadingdone` event fires when the document has loaded all events.
+The `loadingdone` event fires when the document has loaded all fonts.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

The `loadingdone` event is fired when the document has finished loading all the ~~events~~**fonts**.

### Motivation

There was a mistaken word and I have corrected it.

### Additional details

None.

### Related issues and pull requests

None that I know.
